### PR TITLE
Adds test for ctx and a new fix config command

### DIFF
--- a/esque/config/__init__.py
+++ b/esque/config/__init__.py
@@ -67,12 +67,13 @@ def sample_config_path() -> Path:
 
 
 class Config(metaclass=SingletonMeta):
-    def __init__(self):
+    def __init__(self, *, disable_validation=False):
         if not config_path().exists():
             raise ConfigNotExistsException()
         check_config_version(config_path())
         self._cfg = yaml.safe_load(config_path().read_text())
-        esque.validation.validate_esque_config(self._cfg)
+        if not disable_validation:
+            esque.validation.validate_esque_config(self._cfg)
         self._current_dict: Optional[Dict[str, str]] = None
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ from esque.resources.topic import Topic
 # see function get_path_for_config_version
 LOAD_SAMPLE_CONFIG = -1
 LOAD_INTEGRATION_TEST_CONFIG = -2
+LOAD_BROKEN_CONFIG = -3
 LOAD_CURRENT_VERSION = CURRENT_VERSION
 
 
@@ -61,7 +62,7 @@ def config_loader(config_version: int = CURRENT_VERSION) -> Tuple[Path, str]:
     ...
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def load_config(mocker: mock, tmp_path: Path) -> config_loader:
     """
     Loads config of the given version or key into a temporary directory and set this directory as esque config
@@ -98,7 +99,16 @@ def get_path_for_config_version(config_version: int) -> Path:
         return base_path / "integration_test_config.yaml"
     if config_version == LOAD_SAMPLE_CONFIG:
         return esque.config.sample_config_path()
+    if config_version == LOAD_BROKEN_CONFIG:
+        return base_path / "broken_test_config.yaml"
     return base_path / f"v{config_version}_sample.yaml"
+
+
+@pytest.fixture()
+def broken_test_config(load_config: config_loader) -> Config:
+    conffile, _ = load_config(LOAD_BROKEN_CONFIG)
+    esque_config = Config.get_instance()
+    return esque_config
 
 
 @pytest.fixture()

--- a/tests/test_configs/broken_test_config.yaml
+++ b/tests/test_configs/broken_test_config.yaml
@@ -1,0 +1,20 @@
+version: 1
+current_context: not_existing
+contexts:
+  local:
+    bootstrap_servers:
+      - localhost:9092
+    security_protocol: PLAINTEXT
+    schema_registry: http://localhost:8081
+    default_values:
+      num_partitions: 1
+      replication_factor: 1
+
+  docker:
+    bootstrap_servers:
+      - kafka:9093
+    security_protocol: PLAINTEXT
+    schema_registry: http://schema_registry:8081
+    default_values:
+      num_partitions: 1
+      replication_factor: 1

--- a/tests/unit/commands/test_ctx.py
+++ b/tests/unit/commands/test_ctx.py
@@ -1,0 +1,39 @@
+import pytest
+from click.testing import CliRunner
+
+from esque.cli.commands import ctx
+from esque.config import Config
+from tests.conftest import LOAD_INTEGRATION_TEST_CONFIG, config_loader
+
+
+def reload_config(load_config: config_loader, *, config: int = LOAD_INTEGRATION_TEST_CONFIG):
+    conffile, _ = load_config(config)
+    Config.set_instance(Config())
+    return Config.get_instance()
+
+
+def parse_context_output(output: str):
+    return output.strip("\n").split("\n")
+
+
+@pytest.mark.integration
+def test_ctx_switch(non_interactive_cli_runner: CliRunner, load_config: config_loader):
+    esque_config = reload_config(load_config)
+
+    contexts = esque_config.available_contexts
+
+    # Check the current context actually exists
+    result = non_interactive_cli_runner.invoke(ctx, catch_exceptions=False)
+
+    found_contexts = parse_context_output(result.output)
+
+    assert result.exit_code == 0
+    assert found_contexts == contexts
+
+    # Switch once to all contexts
+    for i, context in enumerate(contexts):
+        non_interactive_cli_runner.invoke(ctx, contexts[i], catch_exceptions=False)
+        result = non_interactive_cli_runner.invoke(ctx, catch_exceptions=False)
+
+        assert esque_config.current_context == context
+        assert result.exit_code == 0


### PR DESCRIPTION
Adds a new command `config fix` which automatically fixes simple config errors. For now the only implemented fix is switching away from a now longer existing context (see #139).

Also adds a simple unit test for the context switch.