### PR TITLE
Version bump to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### Version 0.2.0
+* Bugfix for issue #149
 ### Version 0.2.0b3
 * Bugfix #136: Fix wrong schema version for null payload
 * Enhancement #141: Split folder for key and value schema when consuming messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "esque"
-version = "0.2.0-beta.3"
+version = "0.2.0"
 description="esque - an operational kafka tool."
 authors = ["real.digital <opensource@real-digital.de>"]
 license = "MIT"
@@ -27,7 +27,8 @@ classifiers = [
   "Topic :: Software Development",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7"
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8"
   ]
 # esque entrypoint
 [tool.poetry.scripts]


### PR DESCRIPTION
Let's go to a proper version number. :) Kept beta state in the `pyproject.toml`. Can change to production/stable if you disagree