### PR TITLE
Expanded commands for deletion to support multiple arguments.

### DIFF
--- a/esque/cli/commands.py
+++ b/esque/cli/commands.py
@@ -415,12 +415,12 @@ def edit_offsets(state: State, consumer_id: str, topic_name: str):
 
 
 @delete.command("consumergroup")
-@click.argument("consumergroup-name", required=False, type=click.STRING, autocompletion=list_consumergroups, nargs=-1)
+@click.argument("consumergroup-id", required=False, type=click.STRING, autocompletion=list_consumergroups, nargs=-1)
 @default_options
-def delete_consumer_group(state: State, consumergroup_name: Tuple[str]):
+def delete_consumer_group(state: State, consumergroup_id: Tuple[str]):
     """Delete consumer groups
     """
-    consumer_groups = list(consumergroup_name) + get_piped_stdin_arguments()
+    consumer_groups = list(consumergroup_id) + get_piped_stdin_arguments()
     consumergroup_controller: ConsumerGroupController = ConsumerGroupController(state.cluster)
     current_consumergroups = consumergroup_controller.list_consumer_groups()
     existing_consumer_groups: List[str] = []
@@ -635,7 +635,7 @@ def describe_broker(state: State, broker: str, output_format: str):
 
 
 @describe.command("consumergroup", short_help="Describe a consumer group.")
-@click.argument("consumer-id", callback=fallback_to_stdin, autocompletion=list_consumergroups, required=True)
+@click.argument("consumergroup-id", callback=fallback_to_stdin, autocompletion=list_consumergroups, required=True)
 @click.option(
     "--all-partitions",
     help="List status for all topic partitions instead of just summarizing each topic.",
@@ -644,10 +644,10 @@ def describe_broker(state: State, broker: str, output_format: str):
 )
 @output_format_option
 @default_options
-def describe_consumergroup(state: State, consumer_id: str, all_partitions: bool, output_format: str):
+def describe_consumergroup(state: State, consumergroup_id: str, all_partitions: bool, output_format: str):
     """Return information on group coordinator, offsets, watermarks, lag, and various metadata
     for consumer group CONSUMER_GROUP."""
-    consumer_group = ConsumerGroupController(state.cluster).get_consumer_group(consumer_id)
+    consumer_group = ConsumerGroupController(state.cluster).get_consumer_group(consumergroup_id)
     consumer_group_desc = consumer_group.describe(verbose=all_partitions)
 
     click.echo(format_output(consumer_group_desc, output_format))

--- a/esque/cli/commands.py
+++ b/esque/cli/commands.py
@@ -423,22 +423,21 @@ def delete_consumer_group(state: State, consumergroup_name: Tuple[str]):
     consumer_groups = list(consumergroup_name) + get_piped_stdin_arguments()
     consumergroup_controller: ConsumerGroupController = ConsumerGroupController(state.cluster)
     current_consumergroups = consumergroup_controller.list_consumer_groups()
-    click.echo("The following consumer groups will be deleted:")
     existing_consumer_groups: List[str] = []
     for group in consumer_groups:
         if group in current_consumergroups:
-            click.echo(click.style(group, fg="green"))
+            click.echo(f"Deleting {click.style(group, fg='green')}")
             existing_consumer_groups.append(group)
         else:
-            click.echo(click.style(f"{group} — does not exist", fg="yellow"))
+            click.echo(f"Skipping {click.style(group, fg='yellow')} — does not exist")
     if not existing_consumer_groups:
-        click.echo(click.style("The provided list contains no existing consumer groups. Exiting.", fg="red"))
+        click.echo(click.style("The provided list contains no existing consumer groups.", fg="red"))
     else:
         if ensure_approval("Are you sure?", no_verify=state.no_verify):
             consumergroup_controller.delete_consumer_groups(existing_consumer_groups)
             current_consumergroups = consumergroup_controller.list_consumer_groups()
             assert all(consumer_group not in current_consumergroups for consumer_group in existing_consumer_groups)
-            click.echo(click.style(f"Consumer groups '{existing_consumer_groups}' successfully deleted.", fg="green"))
+        click.echo(click.style(f"Consumer groups '{existing_consumer_groups}' successfully deleted.", fg="green"))
 
 
 @delete.command("topic")
@@ -454,22 +453,21 @@ def delete_topic(state: State, topic_name: str):
     topic_names = list(topic_name) + get_piped_stdin_arguments()
     topic_controller = state.cluster.topic_controller
     current_topics = [topic.name for topic in topic_controller.list_topics(get_topic_objects=False)]
-    click.echo("The following topics will be deleted:")
     existing_topics: List[str] = []
     for topic in topic_names:
         if topic in current_topics:
-            click.echo(click.style(topic, fg="green"))
+            click.echo(f"Deleting {click.style(topic, fg='green')}")
             existing_topics.append(topic)
         else:
-            click.echo(click.style(f"{topic} — does not exist", fg="yellow"))
+            click.echo(f"Skipping {click.style(topic, fg='yellow')} — does not exist")
     if not existing_topics:
-        click.echo(click.style("The provided list contains no existing topics. Exiting.", fg="red"))
-    if ensure_approval("Are you sure?", no_verify=state.no_verify):
-        for topic_name in existing_topics:
-            topic_controller.delete_topic(Topic(topic_name))
-            assert topic_name not in (t.name for t in topic_controller.list_topics(get_topic_objects=False))
-
-    click.echo(click.style(f"Topics '{existing_topics}' successfully deleted.", fg="green"))
+        click.echo(click.style("The provided list contains no existing topics.", fg="red"))
+    else:
+        if ensure_approval("Are you sure?", no_verify=state.no_verify):
+            for topic_name in existing_topics:
+                topic_controller.delete_topic(Topic(topic_name))
+                assert topic_name not in (t.name for t in topic_controller.list_topics(get_topic_objects=False))
+            click.echo(click.style(f"Topics '{existing_topics}' successfully deleted.", fg="green"))
 
 
 @esque.command("apply")

--- a/esque/cli/helpers.py
+++ b/esque/cli/helpers.py
@@ -1,6 +1,7 @@
 import pathlib
 import shutil
-from typing import Callable, Dict, Optional, Tuple, Union
+import sys
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import click
 import yaml
@@ -16,6 +17,13 @@ def _isatty(stream) -> bool:
 
 def isatty(stream) -> bool:
     return _isatty(stream)
+
+
+def get_piped_stdin_arguments() -> List[str]:
+    arguments: List[str] = []
+    if not isatty(sys.stdin):
+        arguments += [argument.replace("\n", "") for argument in sys.stdin.readlines()]
+    return arguments
 
 
 def ensure_approval(question: str, *, no_verify: bool = False, default_answer=False) -> bool:

--- a/tests/integration/commands/test_deletion.py
+++ b/tests/integration/commands/test_deletion.py
@@ -33,17 +33,6 @@ def test_topic_deletion_without_verification_does_not_work(
 
 
 @pytest.mark.integration
-def test_delete_topic_without_topic_name_fails(
-    interactive_cli_runner: CliRunner, confluent_admin_client: confluent_kafka.admin.AdminClient
-):
-    n_topics_before = len(confluent_admin_client.list_topics(timeout=5).topics)
-    result = interactive_cli_runner.invoke(delete_topic)
-    n_topics_after = len(confluent_admin_client.list_topics(timeout=5).topics)
-    assert result.exit_code != 0
-    assert n_topics_before == n_topics_after
-
-
-@pytest.mark.integration
 def test_topic_deletion_as_argument_works(
     interactive_cli_runner: CliRunner, confluent_admin_client: confluent_kafka.admin.AdminClient, topic: str
 ):

--- a/tests/integration/commands/test_deletion.py
+++ b/tests/integration/commands/test_deletion.py
@@ -33,6 +33,18 @@ def test_topic_deletion_without_verification_does_not_work(
 
 
 @pytest.mark.integration
+def test_delete_topic_without_topic_name_is_handled(
+    interactive_cli_runner: CliRunner, confluent_admin_client: confluent_kafka.admin.AdminClient
+):
+    n_topics_before = len(confluent_admin_client.list_topics(timeout=5).topics)
+    result = interactive_cli_runner.invoke(delete_topic)
+    n_topics_after = len(confluent_admin_client.list_topics(timeout=5).topics)
+    assert result.exit_code == 0
+    assert n_topics_before == n_topics_after
+    assert "The provided list contains no existing topics." in result.output
+
+
+@pytest.mark.integration
 def test_topic_deletion_as_argument_works(
     interactive_cli_runner: CliRunner, confluent_admin_client: confluent_kafka.admin.AdminClient, topic: str
 ):

--- a/tests/unit/commands/test_multiargs.py
+++ b/tests/unit/commands/test_multiargs.py
@@ -1,0 +1,93 @@
+import random
+from concurrent.futures import Future
+from string import ascii_letters
+
+import confluent_kafka
+import pytest
+from click.testing import CliRunner
+from confluent_kafka.admin import AdminClient
+from confluent_kafka.cimpl import NewTopic, TopicPartition
+
+from esque.cli.commands import delete_consumer_group, delete_topic
+from esque.config import Config
+from esque.controller.consumergroup_controller import ConsumerGroupController
+
+
+def randomly_generated_consumer_groups(filled_topic, unittest_config: Config) -> str:
+    randomly_generated_consumer_group = "".join(random.choices(ascii_letters, k=8))
+    _config = unittest_config.create_confluent_config()
+    _config.update(
+        {
+            "group.id": randomly_generated_consumer_group,
+            "enable.auto.commit": False,
+            "default.topic.config": {"auto.offset.reset": "latest"},
+        }
+    )
+    _consumer = confluent_kafka.Consumer(_config)
+    _consumer.assign([TopicPartition(topic=filled_topic.name, partition=0, offset=0)])
+    for i in range(2):
+        msg = _consumer.consume(timeout=10)[0]
+        _consumer.commit(msg, asynchronous=False)
+    return randomly_generated_consumer_group
+
+
+def randomly_generated_topics(confluent_admin_client: AdminClient) -> str:
+    topic_id = "".join(random.choices(ascii_letters, k=5))
+    future: Future = confluent_admin_client.create_topics(
+        [NewTopic(topic_id, num_partitions=1, replication_factor=1)]
+    )[topic_id]
+    while not future.done() or future.cancelled():
+        if future.result():
+            raise RuntimeError
+    confluent_admin_client.poll(timeout=1)
+    return topic_id
+
+
+@pytest.mark.integration
+def test_topic_deletions_multiple_cli(
+    interactive_cli_runner: CliRunner, confluent_admin_client: confluent_kafka.admin.AdminClient
+):
+    topics_to_delete = [randomly_generated_topics(confluent_admin_client) for _ in range(3)]
+    remaining_topic = randomly_generated_topics(confluent_admin_client)
+    topics_pre_deletion = confluent_admin_client.list_topics(timeout=5).topics.keys()
+    assert all(topic in topics_pre_deletion for topic in topics_to_delete)
+    assert remaining_topic in topics_pre_deletion
+    assert "not_in_the_list_of_topics" not in topics_pre_deletion
+
+    result = interactive_cli_runner.invoke(
+        delete_topic, topics_to_delete + ["not_in_the_list_of_topics"], input="Y\n", catch_exceptions=False
+    )
+    assert result.exit_code == 0
+
+    topics_post_deletion = confluent_admin_client.list_topics(timeout=5).topics.keys()
+    assert all(topic not in topics_post_deletion for topic in topics_to_delete)
+    assert remaining_topic in topics_post_deletion
+    assert all(existing_topic in topics_pre_deletion for existing_topic in topics_post_deletion)
+
+
+@pytest.mark.integration
+def test_consumer_group_deletions_multiple_cli(
+    interactive_cli_runner: CliRunner,
+    consumergroup_controller: ConsumerGroupController,
+    filled_topic,
+    unittest_config: Config,
+):
+    consumer_groups_to_delete = [randomly_generated_consumer_groups(filled_topic, unittest_config) for _ in range(2)]
+    remaining_consumer_group = randomly_generated_consumer_groups(filled_topic, unittest_config)
+    consumer_groups_pre_deletion = consumergroup_controller.list_consumer_groups()
+    assert all(group in consumer_groups_pre_deletion for group in consumer_groups_to_delete)
+    assert remaining_consumer_group in consumer_groups_pre_deletion
+    assert "not_in_the_list_of_consumers" not in consumer_groups_pre_deletion
+
+    result = interactive_cli_runner.invoke(
+        delete_consumer_group,
+        consumer_groups_to_delete + ["not_in_the_list_of_consumers"],
+        input="Y\n",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    consumer_groups_post_deletion = consumergroup_controller.list_consumer_groups()
+    assert all(group not in consumer_groups_post_deletion for group in consumer_groups_to_delete)
+    assert remaining_consumer_group in consumer_groups_post_deletion
+    assert all(existing_group in consumer_groups_pre_deletion for existing_group in consumer_groups_post_deletion)


### PR DESCRIPTION
The purpose of this PR is to introduce support for multiple command-line arguments for topic and consumer group deletions. The arguments can be provided in three different scenarios:
* only command line arguments are used (`esque delete topic topic1 topic2 topic3`)
* arguments are piped in from a different command (`esque get topics | esque delete topic`)
* both (`esque get topics | esque delete topic topic1 topic2`)