### PR TITLE
Add docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,13 @@
 build/
 dist/
 *.egg-info/
-docker-compose.yml
+.env
+.flake8
+.gitignore
+.pre-commit-config.yaml
+CHANGELOG.md
+docker-compose*
+docker_binding.sh
+*Dockerfile
+LICENSE
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM python:3.9
-
-
+FROM python:3.6
 
 RUN git clone --branch "v1.0.0" --depth 1 https://github.com/edenhill/librdkafka.git \
  && cd librdkafka \
@@ -22,17 +20,14 @@ WORKDIR /esque
 RUN pip install -U pip
 RUN pip install --pre poetry
 
-COPY . /esque
+COPY ./pyproject.toml /esque/pyproject.toml
+COPY ./poetry.lock /esque/poetry.lock
 RUN poetry config "virtualenvs.create" "false"
 RUN poetry install
 
-# Create user
-RUN useradd -ms /bin/bash esque
-USER esque
+COPY ./scripts /esque/scripts
+COPY ./tests /esque/tests
+COPY ./esque /esque/esque
+ENTRYPOINT ["/bin/bash"]
 
-ENV PATH="/home/esque/.local/bin:$PATH"
-
-RUN mkdir -p /home/esque/work
-WORKDIR /home/esque/work
-
-ENTRYPOINT ["esque"]
+CMD ["", "pytest", "tests/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.6
+FROM python:3.9
+
+
 
 RUN git clone --branch "v1.0.0" --depth 1 https://github.com/edenhill/librdkafka.git \
  && cd librdkafka \
@@ -20,14 +22,17 @@ WORKDIR /esque
 RUN pip install -U pip
 RUN pip install --pre poetry
 
-COPY ./pyproject.toml /esque/pyproject.toml
-COPY ./poetry.lock /esque/poetry.lock
+COPY . /esque
 RUN poetry config "virtualenvs.create" "false"
 RUN poetry install
 
-COPY ./scripts /esque/scripts
-COPY ./tests /esque/tests
-COPY ./esque /esque/esque
-ENTRYPOINT ["/bin/bash"]
+# Create user
+RUN useradd -ms /bin/bash esque
+USER esque
 
-CMD ["", "pytest", "tests/"]
+ENV PATH="/home/esque/.local/bin:$PATH"
+
+RUN mkdir -p /home/esque/work
+WORKDIR /home/esque/work
+
+ENTRYPOINT ["esque"]

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ publish:
 wheel:
 	@poetry build -v
 
+build-tool-image:
+	@docker build -t esque -f tool.Dockerfile .
+
 linux_release:
 	docker pull quay.io/pypa/manylinux2010_x86_64
 	docker run --rm -t -i -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/make-linux-release.sh

--- a/docker_binding.sh
+++ b/docker_binding.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+esque(){
+  docker run \
+    --mount type=bind,source="$(pwd)",target=/home/esque/work \
+    --mount type=bind,source="${HOME}/.esque/config.yaml",target=/home/esque/work/config.yaml \
+    -e ESQUE_CONF_PATH=/home/esque/work/config.yaml \
+    -e PYTHONPATH=/esque \
+    esque "${@}"
+}

--- a/docker_binding.sh
+++ b/docker_binding.sh
@@ -3,8 +3,8 @@
 esque(){
   docker run \
     --mount type=bind,source="$(pwd)",target=/home/esque/work \
-    --mount type=bind,source="${HOME}/.esque/config.yaml",target=/home/esque/config.yaml \
-    -e ESQUE_CONF_PATH=/home/esque/config.yaml \
+    --mount type=bind,source="${HOME}/.esque/esque_config.yaml",target=/home/esque/esque_config.yaml \
+    -e ESQUE_CONF_PATH=/home/esque/esque_config.yaml \
     -e PYTHONPATH=/esque \
     esque "${@}"
 }

--- a/docker_binding.sh
+++ b/docker_binding.sh
@@ -4,7 +4,8 @@ esque(){
   docker run \
     --mount type=bind,source="$(pwd)",target=/home/esque/work \
     --mount type=bind,source="${HOME}/.esque/esque_config.yaml",target=/home/esque/esque_config.yaml \
+    --rm \
+    -it \
     -e ESQUE_CONF_PATH=/home/esque/esque_config.yaml \
-    -e PYTHONPATH=/esque \
     esque "${@}"
 }

--- a/docker_binding.sh
+++ b/docker_binding.sh
@@ -3,8 +3,8 @@
 esque(){
   docker run \
     --mount type=bind,source="$(pwd)",target=/home/esque/work \
-    --mount type=bind,source="${HOME}/.esque/config.yaml",target=/home/esque/work/config.yaml \
-    -e ESQUE_CONF_PATH=/home/esque/work/config.yaml \
+    --mount type=bind,source="${HOME}/.esque/config.yaml",target=/home/esque/config.yaml \
+    -e ESQUE_CONF_PATH=/home/esque/config.yaml \
     -e PYTHONPATH=/esque \
     esque "${@}"
 }

--- a/tool.Dockerfile
+++ b/tool.Dockerfile
@@ -13,8 +13,6 @@ RUN git clone --branch "1.4.0" --depth 1 https://github.com/edenhill/kafkacat.gi
  && cd .. \
  && rm -rf kafkacat/
 
-RUN mkdir -p /esque
-
 WORKDIR /esque
 
 RUN pip install -U pip

--- a/tool.Dockerfile
+++ b/tool.Dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.9
+
+RUN git clone --branch "v1.0.0" --depth 1 https://github.com/edenhill/librdkafka.git \
+ && cd librdkafka \
+ && ./configure --prefix /usr \
+ && make \
+ && make install
+
+RUN git clone --branch "1.4.0" --depth 1 https://github.com/edenhill/kafkacat.git \
+ && cd kafkacat \
+ && ./bootstrap.sh \
+ && cp kafkacat /usr/bin/ \
+ && cd .. \
+ && rm -rf kafkacat/
+
+RUN mkdir -p /esque
+
+WORKDIR /esque
+
+RUN pip install -U pip
+RUN pip install --pre poetry
+
+COPY . /esque
+RUN poetry config "virtualenvs.create" "false"
+RUN poetry install
+
+# Create user
+RUN useradd -ms /bin/bash esque
+USER esque
+
+ENV PATH="/home/esque/.local/bin:$PATH"
+
+RUN mkdir -p /home/esque/work
+WORKDIR /home/esque/work
+
+ENTRYPOINT ["esque"]

--- a/tool.Dockerfile
+++ b/tool.Dockerfile
@@ -10,12 +10,10 @@ RUN apt-get update \
         /var/cache/debconf \
         /tmp/* \
     && apt-get clean \
-    && pip install -U pip
+    && pip install -U pip \
+    && pip install --pre poetry
 
 WORKDIR /esque
-
-RUN pip install -U pip
-RUN pip install --pre poetry
 
 COPY . /esque
 RUN poetry config "virtualenvs.create" "false"

--- a/tool.Dockerfile
+++ b/tool.Dockerfile
@@ -28,7 +28,6 @@ USER esque
 
 ENV PATH="/home/esque/.local/bin:$PATH"
 
-RUN mkdir -p /home/esque/work
 WORKDIR /home/esque/work
 
 ENTRYPOINT ["esque"]

--- a/tool.Dockerfile
+++ b/tool.Dockerfile
@@ -1,17 +1,16 @@
 FROM python:3.9
 
-RUN git clone --branch "v1.0.0" --depth 1 https://github.com/edenhill/librdkafka.git \
- && cd librdkafka \
- && ./configure --prefix /usr \
- && make \
- && make install
-
-RUN git clone --branch "1.4.0" --depth 1 https://github.com/edenhill/kafkacat.git \
- && cd kafkacat \
- && ./bootstrap.sh \
- && cp kafkacat /usr/bin/ \
- && cd .. \
- && rm -rf kafkacat/
+RUN apt-get update \
+    && apt-get upgrade \
+    && apt-get install --yes --no-install-recommends \
+        kafkacat \
+        vim \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /var/cache/debconf \
+        /tmp/* \
+    && apt-get clean \
+    && pip install -U pip
 
 WORKDIR /esque
 
@@ -25,8 +24,6 @@ RUN poetry install
 # Create user
 RUN useradd -ms /bin/bash esque
 USER esque
-
-ENV PATH="/home/esque/.local/bin:$PATH"
 
 WORKDIR /home/esque/work
 

--- a/tool.Dockerfile
+++ b/tool.Dockerfile
@@ -13,12 +13,10 @@ RUN apt-get update \
     && pip install --pre poetry
 
 WORKDIR /esque
-
 COPY . /esque
 RUN poetry config "virtualenvs.create" "false"
 RUN poetry install
 
-# Create user
 RUN useradd -ms /bin/bash esque
 USER esque
 

--- a/tool.Dockerfile
+++ b/tool.Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
         /var/lib/apt/lists/* \
         /var/cache/debconf \
         /tmp/* \
-    && apt-get clean \
     && pip install -U pip \
     && pip install --pre poetry
 


### PR DESCRIPTION
Added a dockerfile and toolbinding which can act as a drop-in replacement for the locally installed pip version. Should help to nicely decouple esque from the system's python interpreter. 

I don't know how to push to your docker registry. If you could add that we can even provide a ready to use docker image.