### PR TITLE
Don't pull partition data on apply

### DIFF
--- a/esque/cli/commands.py
+++ b/esque/cli/commands.py
@@ -502,7 +502,7 @@ def apply(state: State, file: str):
 
     # Get topic data based on the cluster state
     topic_controller = state.cluster.topic_controller
-    cluster_topics = topic_controller.list_topics(search_string="|".join(yaml_topic_names))
+    cluster_topics = topic_controller.list_topics(search_string="|".join(yaml_topic_names), get_partitions=False)
     cluster_topic_names = [t.name for t in cluster_topics]
 
     # Calculate changes

--- a/esque/controller/topic_controller.py
+++ b/esque/controller/topic_controller.py
@@ -47,7 +47,7 @@ class TopicController:
             topic_names = sorted(topic_names)
 
         if get_topic_objects:
-            topics = [self.get_cluster_topic(topic_name, retrieve_partition_data=False) for topic_name in topic_names]
+            topics = [self.get_cluster_topic(topic_name, retrieve_partition_data=get_partitions) for topic_name in topic_names]
         else:
             topics = list(map(self.get_local_topic, topic_names))
         return topics

--- a/esque/controller/topic_controller.py
+++ b/esque/controller/topic_controller.py
@@ -47,7 +47,10 @@ class TopicController:
             topic_names = sorted(topic_names)
 
         if get_topic_objects:
-            topics = [self.get_cluster_topic(topic_name, retrieve_partition_data=get_partitions) for topic_name in topic_names]
+            topics = [
+                self.get_cluster_topic(topic_name, retrieve_partition_data=get_partitions)
+                for topic_name in topic_names
+            ]
         else:
             topics = list(map(self.get_local_topic, topic_names))
         return topics

--- a/esque/controller/topic_controller.py
+++ b/esque/controller/topic_controller.py
@@ -131,7 +131,9 @@ class TopicController:
     ) -> Topic:
         """Takes a topic and, based on its name, updates all attributes from the cluster"""
 
-        topic.partition_data = self._get_partitions(topic, retrieve_last_timestamp, get_partition_data=retrieve_partition_data)
+        topic.partition_data = self._get_partitions(
+            topic, retrieve_last_timestamp, get_partition_data=retrieve_partition_data
+        )
         topic.config = self.cluster.retrieve_config(ConfigResource.Type.TOPIC, topic.name)
 
         topic.is_only_local = False

--- a/esque/controller/topic_controller.py
+++ b/esque/controller/topic_controller.py
@@ -131,10 +131,7 @@ class TopicController:
     ) -> Topic:
         """Takes a topic and, based on its name, updates all attributes from the cluster"""
 
-        if retrieve_partition_data:
-            topic.partition_data = self._get_partitions(topic, retrieve_last_timestamp)
-        else:
-            topic.partition_data = self._get_partitions(topic, retrieve_last_timestamp, get_partition_data=False)
+        topic.partition_data = self._get_partitions(topic, retrieve_last_timestamp, get_partition_data=retrieve_partition_data)
         topic.config = self.cluster.retrieve_config(ConfigResource.Type.TOPIC, topic.name)
 
         topic.is_only_local = False

--- a/esque/controller/topic_controller.py
+++ b/esque/controller/topic_controller.py
@@ -148,6 +148,10 @@ class TopicController:
     def _get_partitions(
         self, topic: Topic, retrieve_last_timestamp: bool, get_partition_data: bool = True
     ) -> List[Partition]:
+        assert not (
+            retrieve_last_timestamp and not get_partition_data
+        ), "Can not retrieve timestamp without partition data"
+
         config = Config.get_instance().create_confluent_config()
         config.update({"group.id": ESQUE_GROUP_ID, "topic.metadata.refresh.interval.ms": "250"})
         with closing(confluent_kafka.Consumer(config)) as consumer:

--- a/esque/controller/topic_controller.py
+++ b/esque/controller/topic_controller.py
@@ -2,7 +2,6 @@ import logging
 import re
 import time
 from contextlib import closing
-from functools import partial
 from itertools import islice
 from logging import Logger
 from typing import TYPE_CHECKING, Dict, List, Optional

--- a/esque/controller/topic_controller.py
+++ b/esque/controller/topic_controller.py
@@ -2,6 +2,7 @@ import logging
 import re
 import time
 from contextlib import closing
+from functools import partial
 from itertools import islice
 from logging import Logger
 from typing import TYPE_CHECKING, Dict, List, Optional
@@ -35,6 +36,7 @@ class TopicController:
         sort: bool = True,
         hide_internal: bool = False,
         get_topic_objects: bool = True,
+        get_partitions: bool = True,
     ) -> List[Topic]:
         topic_results = self.cluster.confluent_client.list_topics().topics.values()
         topic_names = [t.topic for t in topic_results]
@@ -46,7 +48,10 @@ class TopicController:
             topic_names = sorted(topic_names)
 
         if get_topic_objects:
-            topics = list(map(self.get_cluster_topic, topic_names))
+            if get_partitions:
+                topics = list(map(self.get_cluster_topic, topic_names))
+            else:
+                topics = list(map(partial(self.get_cluster_topic, retrieve_partition_data=False), topic_names))
         else:
             topics = list(map(self.get_local_topic, topic_names))
         return topics
@@ -96,9 +101,9 @@ class TopicController:
         future = self.cluster.confluent_client.delete_topics([topic.name])[topic.name]
         ensure_kafka_future_done(future)
 
-    def get_cluster_topic(self, topic_name: str, *, retrieve_last_timestamp: bool = False) -> Topic:
+    def get_cluster_topic(self, topic_name: str, *, retrieve_last_timestamp: bool = False, retrieve_partition_data: bool = True) -> Topic:
         """Convenience function getting an existing topic based on topic_name"""
-        return self.update_from_cluster(Topic(topic_name), retrieve_last_timestamp=retrieve_last_timestamp)
+        return self.update_from_cluster(Topic(topic_name), retrieve_last_timestamp=retrieve_last_timestamp, retrieve_partition_data=retrieve_partition_data)
 
     def get_local_topic(self, topic_name: str) -> Topic:
         return Topic(topic_name)
@@ -119,23 +124,27 @@ class TopicController:
             topic_partition.partition: topic_partition.offset for topic_partition in topic_partitions_with_new_offsets
         }
 
-    def update_from_cluster(self, topic: Topic, *, retrieve_last_timestamp: bool = False) -> Topic:
+    def update_from_cluster(self, topic: Topic, *, retrieve_last_timestamp: bool = False, retrieve_partition_data: bool = True) -> Topic:
         """Takes a topic and, based on its name, updates all attributes from the cluster"""
 
-        topic.partition_data = self._get_partition_data(topic, retrieve_last_timestamp)
+        if retrieve_partition_data:
+            topic.partition_data = self._get_partitions(topic, retrieve_last_timestamp)
+        else:
+            topic.partition_data = self._get_partitions(topic, retrieve_last_timestamp, get_partition_data=False)
         topic.config = self.cluster.retrieve_config(ConfigResource.Type.TOPIC, topic.name)
 
         topic.is_only_local = False
 
         return topic
 
-    def _get_partition_data(self, topic: Topic, retrieve_last_timestamp: bool) -> List[Partition]:
-
+    def _get_partitions(self, topic: Topic, retrieve_last_timestamp: bool, get_partition_data: bool = True) -> List[Partition]:
         config = Config.get_instance().create_confluent_config()
         config.update({"group.id": ESQUE_GROUP_ID, "topic.metadata.refresh.interval.ms": "250"})
         with closing(confluent_kafka.Consumer(config)) as consumer:
             confluent_topic = consumer.list_topics(topic=topic.name).topics[topic.name]
             partitions: List[Partition] = []
+            if not get_partition_data:
+                return [Partition(partition_id, 0, 0, meta.isrs, meta.leader, meta.replicas, None) for partition_id, meta in confluent_topic.partitions.items()]
             for partition_id, meta in confluent_topic.partitions.items():
                 try:
                     low, high = consumer.get_watermark_offsets(
@@ -168,7 +177,7 @@ class TopicController:
     def diff_with_cluster(self, local_topic: Topic) -> TopicDiff:
         assert local_topic.is_only_local, "Can only diff local topics with remote"
 
-        cluster_topic = self.get_cluster_topic(local_topic.name)
+        cluster_topic = self.get_cluster_topic(local_topic.name, retrieve_partition_data=False)
         diffs = TopicDiff()
         diffs.set_diff("num_partitions", cluster_topic.num_partitions, local_topic.num_partitions)
         diffs.set_diff("replication_factor", cluster_topic.replication_factor, local_topic.replication_factor)

--- a/esque/controller/topic_controller.py
+++ b/esque/controller/topic_controller.py
@@ -155,7 +155,7 @@ class TopicController:
             partitions: List[Partition] = []
             if not get_partition_data:
                 return [
-                    Partition(partition_id, 0, 0, meta.isrs, meta.leader, meta.replicas, None)
+                    Partition(partition_id, -1, -1, meta.isrs, meta.leader, meta.replicas, None)
                     for partition_id, meta in confluent_topic.partitions.items()
                 ]
             for partition_id, meta in confluent_topic.partitions.items():

--- a/esque/controller/topic_controller.py
+++ b/esque/controller/topic_controller.py
@@ -48,10 +48,7 @@ class TopicController:
             topic_names = sorted(topic_names)
 
         if get_topic_objects:
-            if get_partitions:
-                topics = list(map(self.get_cluster_topic, topic_names))
-            else:
-                topics = list(map(partial(self.get_cluster_topic, retrieve_partition_data=False), topic_names))
+            topics = [self.get_cluster_topic(topic_name, retrieve_partition_data=False) for topic_name in topic_names]
         else:
             topics = list(map(self.get_local_topic, topic_names))
         return topics


### PR DESCRIPTION
This is an attempt to speed up the apply command.
Problem is that we are retrieving all partitions data every time we touch a topic. Which really impacts the time apply needs to initially load the diff.
I also saw that we scrape each topic twice. Once during initial load and once during the diff. But I left that for now.
This should fix #183.